### PR TITLE
[bugfix] remove ansible_vault_password_file

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,7 +19,9 @@ provisioner:
   additional_copy_path:
     - extra_modules
     - filter_plugins
-  ansible_vault_password_file: <%= File.expand_path(ENV['ANSIBLE_VAULT_PASSWORD_FILE'] || '') %>
+<% if ENV["ANSIBLE_VAULT_PASSWORD_FILE"] %>
+  ansible_vault_password_file: <%= File.expand_path(ENV["ANSIBLE_VAULT_PASSWORD_FILE"]) %>
+<% end %>
 
 platforms:
   - name: freebsd-10.3-amd64

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,9 +19,6 @@ provisioner:
   additional_copy_path:
     - extra_modules
     - filter_plugins
-<% if ENV["ANSIBLE_VAULT_PASSWORD_FILE"] %>
-  ansible_vault_password_file: <%= File.expand_path(ENV["ANSIBLE_VAULT_PASSWORD_FILE"]) %>
-<% end %>
 
 platforms:
   - name: freebsd-10.3-amd64


### PR DESCRIPTION
very few roles need ansible_vault_password_file.

recent ansible version checks the provided password
is valid. setting empty password will cause failure.

TODO: warn in qansible if the attribute exists